### PR TITLE
ENG-1773: Add Terraformer IAM permissions for colon-format authorized tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5471,6 +5471,20 @@ resource "aws_iam_role_policy" "instance_orchestrator_terraformer_lambda_policy"
       }
     },
     {
+      "Sid": "S3BucketMetaWhenAuthorizedColon",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/xosphere:instance-orchestrator:authorized": "true"
+        }
+      }
+    },
+    {
       "Sid": "S3StateAccessWhenAuthorized",
       "Effect": "Allow",
       "Action": [
@@ -5482,6 +5496,21 @@ resource "aws_iam_role_policy" "instance_orchestrator_terraformer_lambda_policy"
       "Condition": {
         "StringEquals": {
           "s3:ExistingObjectTag/xosphere.io/instance-orchestrator/authorized": "true"
+        }
+      }
+    },
+    {
+      "Sid": "S3StateAccessWhenAuthorizedColon",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:PutObjectTagging"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "s3:ExistingObjectTag/xosphere:instance-orchestrator:authorized": "true"
         }
       }
     },
@@ -5499,6 +5528,23 @@ resource "aws_iam_role_policy" "instance_orchestrator_terraformer_lambda_policy"
       "Condition": {
         "StringEquals": {
           "dynamodb:ResourceTag/xosphere.io/instance-orchestrator/authorized": "true"
+        }
+      }
+    },
+    {
+      "Sid": "TerraformLockTableAccessWhenAuthorizedColon",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:DescribeTable",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "dynamodb:ResourceTag/xosphere:instance-orchestrator:authorized": "true"
         }
       }
     },


### PR DESCRIPTION
Add support for both slash and colon tag formats in Terraformer IAM policy:
- S3BucketMetaWhenAuthorizedColon: ListBucket and GetBucketLocation permissions
- S3StateAccessWhenAuthorizedColon: GetObject, PutObject, and PutObjectTagging permissions
- TerraformLockTableAccessWhenAuthorizedColon: DynamoDB lock table access permissions

These changes ensure compatibility with both tag formats while maintaining backward compatibility with existing deployments using slash-format tags.