### PR TITLE
ENG-1794: Bump terraformer ephemeral storage to 2048

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -342,7 +342,7 @@ variable "terraformer_memory_size" {
 
 variable "terraformer_ephemeral_storage" {
   description = "Ephemeral storage size allocated to Lambda"
-  default = 1024
+  default = 2048
 }
 
 variable "terraformer_lambda_timeout" {


### PR DESCRIPTION
Align the Terraform module default with the
CloudFormation template, which already uses 2048.