### PR TITLE
ENG-1820: Add DescribeNetworkInterfaces to terraformer IAM

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5524,6 +5524,7 @@ resource "aws_iam_role_policy" "instance_orchestrator_terraformer_lambda_policy"
         "ec2:DescribeInstanceCreditSpecifications",
         "ec2:DescribeInstances",
         "ec2:DescribeInstanceTypes",
+        "ec2:DescribeNetworkInterfaces",
         "ec2:DescribeTags",
         "ec2:DescribeVolumes"
       ],


### PR DESCRIPTION
The terraformer uses DescribeNetworkInterfaces as a fallback for ENI attachment ID discovery when Terraform state doesn't populate the attachment block. The IAM policy was missing this permission.