### PR TITLE
ENG-1798: Add cross-account Terraform backend assume-role support

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -335,6 +335,21 @@ variable "terraform_backend_dynamodb_table" {
   default = ""
 }
 
+variable "terraform_backend_assume_role_arn" {
+  description = "Optional role ARN to assume for Terraform backend operations"
+  default = ""
+}
+
+variable "terraform_backend_assume_role_external_id" {
+  description = "Optional external ID for Terraform backend assume role"
+  default = ""
+}
+
+variable "terraform_backend_assume_role_session_name" {
+  description = "Optional session name for Terraform backend assume role"
+  default = "xosphere-terraformer"
+}
+
 variable "terraformer_memory_size" {
   description = "Memory size allocated to Lambda"
   default = 1024


### PR DESCRIPTION
Summary

Add optional assume_role configuration to Terraform backend for cross-account S3/DynamoDB backends. Support configured via CFN parameters, Terraform module variables, and Xogroup tags (colon and slash formats).

Problem

When Terraform backend (S3 + DynamoDB) resides in another AWS account, Terraform backend operations fail because backend block lacks assume_role configuration. Even with cross-account IAM permissions, Terraform requires explicit assume_role in the backend block.

Solution

- Add new tag keys for assume role ARN, external ID, session name
- Read tags with precedence: colon format > slash format > stack params > module defaults
- Inject assume_role block into generated backend config when ARN is set
- Add CFN parameters and Terraform module variables for assume role
- Add conditional sts:AssumeRole permission (explicit ARN + tag-based)
- Update terraform init to use -reconfigure flag
- Add documentation with role creation examples

Maintains full backward compatibility when assume role is not configured.