### PR TITLE
ENG-1800: Add use_lockfile support for Terraform backend

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
   xo_account_region = "us-west-2"
   has_global_terraform_settings = var.terraform_version != "" || var.terraform_aws_provider_version != "" || var.terraform_backend_aws_region != "" || var.terraform_backend_s3_bucket != "" || var.terraform_backend_s3_key != ""
   needDefineTerraformS3Permission = var.terraform_backend_s3_bucket != "" && var.terraform_backend_aws_region != ""
-  needDefineTerraformDynamoDBPermission = var.terraform_backend_dynamodb_table != ""
+  needDefineTerraformDynamoDBPermission = var.terraform_backend_use_lockfile != "true" && var.terraform_backend_dynamodb_table != ""
   needDefineTerraformAssumeRolePermission = var.terraform_backend_assume_role_arn != ""
   has_k8s_vpc_config = ((length(var.k8s_vpc_security_group_ids) > 0) && (length(var.k8s_vpc_subnet_ids) > 0))
   has_k8s_vpc_config_string = local.has_k8s_vpc_config ? "true" : "false"
@@ -5362,6 +5362,7 @@ resource "aws_lambda_function" "instance_orchestrator_terraformer_lambda" {
       TERRAFORM_BACKEND_ASSUME_ROLE_ARN = var.terraform_backend_assume_role_arn
       TERRAFORM_BACKEND_ASSUME_ROLE_EXTERNAL_ID = var.terraform_backend_assume_role_external_id
       TERRAFORM_BACKEND_ASSUME_ROLE_SESSION_NAME = var.terraform_backend_assume_role_session_name
+      TERRAFORM_BACKEND_USE_LOCKFILE = var.terraform_backend_use_lockfile
     }
   }
   function_name = "xosphere-instance-orchestrator-terraformer"

--- a/variables.tf
+++ b/variables.tf
@@ -350,6 +350,11 @@ variable "terraform_backend_assume_role_session_name" {
   default = "xosphere-terraformer"
 }
 
+variable "terraform_backend_use_lockfile" {
+  description = "If set to \"true\", use S3 native lock file for Terraform state locking instead of DynamoDB."
+  default = ""
+}
+
 variable "terraformer_memory_size" {
   description = "Memory size allocated to Lambda"
   default = 1024


### PR DESCRIPTION
Port CFN changes to the Terraform module. When
terraform_backend_use_lockfile is set to "true", skip DynamoDB IAM permissions and pass the setting to the terraformer Lambda via TERRAFORM_BACKEND_USE_LOCKFILE env var.

- Add terraform_backend_use_lockfile variable
- Gate needDefineTerraformDynamoDBPermission on use_lockfile != "true"
- Pass env var to terraformer Lambda