### PR TITLE
ENG-1741: Expose AMI cleaner retention settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3770,6 +3770,8 @@ resource "aws_lambda_function" "instance_orchestrator_ami_cleaner_lambda" {
   environment {
     variables = {
       REGIONS = local.regions
+      MAX_IMAGES_TO_RETAIN = var.ami_cleaner_max_images_to_retain
+      ORPHANED_IMAGE_RETENTION_DAYS = var.ami_cleaner_orphaned_image_retention_days
     }
   }
   function_name = "xosphere-instance-orchestrator-ami-cleaner"

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,18 @@ variable "ami_cleaner_cron_schedule" {
   default = "7 10 * * ? *"
 }
 
+variable "ami_cleaner_max_images_to_retain" {
+  description = "Max number of images in a chain of instance replacements to retain"
+  type    = number
+  default = 3
+}
+
+variable "ami_cleaner_orphaned_image_retention_days" {
+  description = "Number of days to retain images for instances that no longer exist before deleting them"
+  type    = number
+  default = 30
+}
+
 variable "io_launcher_memory_size" {
   description = "Memory size allocated to Lambda"
   default = 256


### PR DESCRIPTION
Add Terraform variables for the two new AMI cleaner settings introduced in xosphere-io-go-io:
- ami_cleaner_max_images_to_retain (default 3)
- ami_cleaner_orphaned_image_retention_days (default 30)

Both are passed as environment variables to the AMI cleaner Lambda function.